### PR TITLE
users table 구조 변경, register시 email 중복 방지

### DIFF
--- a/2021_2_backEnd/backEnd/user/logout.py
+++ b/2021_2_backEnd/backEnd/user/logout.py
@@ -18,4 +18,4 @@ class userLogout(Resource):
         db.execute(query, (jti,))
         db.commit()
 
-        return {'message' : 'Log Out Success'}
+        return {'message' : 'Logout Success'}

--- a/2021_2_backEnd/backEnd/user/register.py
+++ b/2021_2_backEnd/backEnd/user/register.py
@@ -2,6 +2,7 @@
 from flask import request
 from flask_restx import Namespace, Resource
 from .. import database
+from pymysql import err
 
 Register = Namespace('Register')
 
@@ -9,12 +10,17 @@ Register = Namespace('Register')
 class register(Resource):
     def post(self):
         data = request.json
-        db_class = database.DBClass()
+        db = database.DBClass()
 
-        query = '''INSERT INTO users(email, password, name)
-            VALUES(%(email)s, %(password)s, %(name)s);
-            '''
-        db_class.execute(query, data)
-        db_class.commit()
-
-        return {"message":"Success"}
+        # 중복된 email 입력 시 예외 처리
+        try:
+            query = '''INSERT INTO users(email, password, name)
+                VALUES(%(email)s, %(password)s, %(name)s);
+                '''
+            db.execute(query, data)
+            message = "Register Success"
+        except err.IntegrityError:
+            message = "Register Failed(Email Duplicated)"
+        finally:
+            db.commit()
+        return {"message": message }

--- a/2021_2_backEnd/backendDB.sql
+++ b/2021_2_backEnd/backendDB.sql
@@ -1,0 +1,57 @@
+-- MySQL dump 10.13  Distrib 5.6.36, for Win64 (x86_64)
+--
+-- Host: localhost    Database: backend_test
+-- ------------------------------------------------------
+-- Server version	5.6.36-log
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `revoked_tokens`
+--
+
+DROP TABLE IF EXISTS `revoked_tokens`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `revoked_tokens` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `jti` varchar(500) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `users`
+--
+
+DROP TABLE IF EXISTS `users`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `users` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `email` varchar(200) DEFAULT NULL,
+  `password` varchar(200) DEFAULT NULL,
+  `name` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2021-08-13 23:35:52

--- a/2021_2_backEnd/backendDB.sql
+++ b/2021_2_backEnd/backendDB.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 5.6.36, for Win64 (x86_64)
+-- MySQL dump 10.13  Distrib 5.6.35, for Win64 (x86_64)
 --
 -- Host: localhost    Database: backend_test
 -- ------------------------------------------------------
--- Server version	5.6.36-log
+-- Server version	5.6.35-log
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -26,7 +26,7 @@ CREATE TABLE `revoked_tokens` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `jti` varchar(500) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -41,8 +41,9 @@ CREATE TABLE `users` (
   `email` varchar(200) DEFAULT NULL,
   `password` varchar(200) DEFAULT NULL,
   `name` varchar(200) DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8;
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniqueEmail` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -54,4 +55,4 @@ CREATE TABLE `users` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2021-08-13 23:35:52
+-- Dump completed on 2021-08-17 17:20:41


### PR DESCRIPTION
users table의 email colomn을 unique key로 변경,
현재 db구조 적용을 원할 시 mysql -u 'mysql id' -p '덮어씌울 db' < 'backendDB.sql' 명령어 사용

 try, except 사용해서 register시 이미 db에 존재하는 email로 가입을 시도하면 "register failed(duplicated email)" 메시지 반환