### PR TITLE
주석 작성, 클라이언트로부터 전달된 인자들 무결성(유효성) 체크 기능 추가

### DIFF
--- a/2021_2_backEnd/backEnd/__init__.py
+++ b/2021_2_backEnd/backEnd/__init__.py
@@ -1,5 +1,5 @@
 # __ini__.py
-from flask import Flask
+from flask import Flask, jsonify
 from flask_restx import Api
 from flask_jwt_extended import JWTManager
 from .test.test import Test
@@ -7,12 +7,22 @@ from .user.register import Register
 from .user.login import Login
 from .user.logintest import LoginTest
 from .user.logout import Logout
+from flask_request_validator.error_formatter import demo_error_formatter
+from flask_request_validator.exceptions import InvalidRequestError 
 
 app = Flask(__name__)
-app.config.update(JWT_SECRET_KEY = "backendTest")
+app.config.update(JWT_SECRET_KEY = "backendTest") # jwt encoding을 위한 secret key, 추후 수정 필요
 jwt = JWTManager(app)
 api = Api(app)
 
+# request 유효성 체크 에러 메시지 처리
+@app.errorhandler(InvalidRequestError)
+def data_error(e):
+    ReqErr = demo_error_formatter(e)[0]
+
+    return jsonify(demo_error_formatter(e)[0]), 400
+
+# namespace 등록
 api.add_namespace(Test,'/')
 api.add_namespace(Register,'/user')
 api.add_namespace(Login, '/user')

--- a/2021_2_backEnd/backEnd/database.py
+++ b/2021_2_backEnd/backEnd/database.py
@@ -2,7 +2,9 @@
 
 import pymysql
 
+# Mysql Connection을 위한 객체 정의
 class DBClass():
+    # mysql 계정 정보, 퀴리문 실행 후 리턴값은 dictionary형식으로 반환 
     def __init__(self):
         self.db = pymysql.connect(
             user        = 'root',
@@ -17,15 +19,18 @@ class DBClass():
     def execute(self, query, args):
         self.cursor.execute(query, args)
 
+    # 쿼리를 수행한 결과를 전부 반환
     def executeAll(self, query, args):
         self.cursor.execute(query, args)
         row = self.cursor.fetchall()
         return row
 
+    # 쿼리를 수행한 결과 중 최상위 row만 반환
     def executeOne(self, query, args):
         self.cursor.execute(query, args)
         row = self.cursor.fetchone()
         return row
 
+    # commit
     def commit(self):
         self.db.commit()

--- a/2021_2_backEnd/backEnd/user/login.py
+++ b/2021_2_backEnd/backEnd/user/login.py
@@ -1,27 +1,35 @@
 # login.py
 from flask import request
 from flask_restx import Namespace, Resource 
-from flask_jwt_extended import *
+from flask_jwt_extended import create_access_token
 from .. import database
+from flask_request_validator import *
 
 Login = Namespace('Login')
 
+# userLogin 클래스, 클라이언트로부터 이메일과 비밀번호를 받아 jwt access token을 반환한다.
 @Login.route('/login')
 class userLogin(Resource):
-    def post(self):
-
+    @validate_params(
+        Param('email', JSON, str, rules=[Pattern(r'^[\w+-_.]+@[\w-]+\.[a-zA-Z-.]+$')]),   # 이메일 형식 체크
+        Param('password', JSON, str, rules=CompositeRule(Pattern(r'(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[^\w\s]).*'), MinLength(8), MaxLength(20))),   # 비밀번호 형식 체크(한, 영, 숫자, 특수문자 포함)
+    )
+    def post(self, *args):
+        
+        # json형식으로 data parsing, mysql connection을 위한 객체 생성
         data = request.json
-
         db = database.DBClass()
         query = '''
             SELECT * FROM users WHERE email=%(email)s AND password=%(password)s;
         '''
         dbData = db.executeOne(query, data)
 
-        if dbData:
+        # users 테이블에 일치하는 이메일과 비밀번호 한 쌍이 존재한다면 jwt토큰과 success메시지 반환
+        if dbData is not None:
             return {
                 "message" : "Login Success",
                 "access token" : create_access_token(identity = data['email'], expires_delta = False)
-                }
+                }, 200
+        # 일치하는 이메일이 없을 경우에는 failed 메시지 반환
         else:
-            return {"message" : "Login Failed"}
+            return {"message" : "Login Failed"}, 400

--- a/2021_2_backEnd/backEnd/user/logout.py
+++ b/2021_2_backEnd/backEnd/user/logout.py
@@ -5,11 +5,15 @@ from .. import database
 
 Logout = Namespace('Logout')
 
+# logout 클래스, 현재 발급되어 있는 jwt토큰을 폐기하고 블랙리스트에 등록한다.
 @Logout.route('/logout')
 class userLogout(Resource):
+    # jwt 토큰이 header에 존재해야 접근 가능
     @jwt_required()
+    # DELETE method로 url에 접근했을 때
     def delete(self):
 
+        # 받은 request의 header에서 jwt토큰을 분리해서 DB의 블랙리스트 테이블(revoked_tokens)에 등록한다.
         jti = get_jwt()['jti']
         db = database.DBClass()
         query = '''

--- a/2021_2_backEnd/backEnd/user/register.py
+++ b/2021_2_backEnd/backEnd/user/register.py
@@ -3,12 +3,22 @@ from flask import request
 from flask_restx import Namespace, Resource
 from .. import database
 from pymysql import err
+from flask_request_validator import *
 
 Register = Namespace('Register')
 
+# 일반 이메일 회원가입 클래스
 @Register.route('/register')
 class register(Resource):
-    def post(self):
+    # request 유효성 검사
+    @validate_params(
+        Param('email', JSON, str, rules=[Pattern(r'^[\w+-_.]+@[\w-]+\.[a-zA-Z-.]+$')]),   # 이메일 형식 체크
+        Param('name', JSON, str, rules=CompositeRule(Pattern(r'[a-zA-Z가-힣]'), MinLength(1))),   # 이름 형식 체크
+        Param('password', JSON, str, rules=CompositeRule(Pattern(r'(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[^\w\s]).*'), MinLength(8), MaxLength(20))),   # 비밀번호 형식 체크(한, 영, 숫자, 특수문자 포함)
+    )
+    # POST method로 'email', 'name', 'password' 필드를 가진 데이터를 body에 담아서 접근했을 때
+    def post(self, *args):
+        # json형식으로 data parsing, mysql connection을 위한 객체 생성
         data = request.json
         db = database.DBClass()
 
@@ -19,8 +29,10 @@ class register(Resource):
                 '''
             db.execute(query, data)
             message = "Register Success"
+            code = 201
         except err.IntegrityError:
             message = "Register Failed(Email Duplicated)"
+            code = 400
         finally:
             db.commit()
-        return {"message": message }
+        return {"message": message }, code

--- a/2021_2_backEnd/requirements.txt
+++ b/2021_2_backEnd/requirements.txt
@@ -8,6 +8,7 @@ colorama==0.4.4
 Flask==2.0.1
 Flask-JWT-Extended==4.2.3
 Flask-Migrate==3.0.1
+flask-request-validator==4.2.0
 flask-restx==0.5.0
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==0.15.1


### PR DESCRIPTION
logintest.py와 test폴더의 파일들을 제외한 파일들에 주석 간단히 작성
register와 login시 클라이언트로부터 전달받는 json객체의 내용을 검사하여 유효한지 판단하는 기능 추가
 - 임시적으로 비밀번호의 자리수는 8~20, 반드시 영어, 숫자, 특수문자를 포함하도록 설정