### PR TITLE
mail 인증 api 작성, 전체적인 return json객체 형식 수정, error handler 수정, register api 문서 작성 완료

### DIFF
--- a/2021_2_backEnd/backEnd/__init__.py
+++ b/2021_2_backEnd/backEnd/__init__.py
@@ -10,10 +10,12 @@ from user.login import Login
 from user.logintest import LoginTest
 from user.logout import Logout
 from user.mail import Email, mail
+import database, werkzeug.exceptions
 
 app = Flask(__name__)
 app.config.update(JWT_SECRET_KEY = "backendTest") # jwt encoding을 위한 secret key, 추후 수정 필요
 
+app.config['JWT_ERROR_MESSAGE_KEY'] = 'message'
 app.config['MAIL_SERVER'] = 'smtp.gmail.com'
 app.config['MAIL_PORT'] = 465
 app.config['MAIL_USERNAME'] = 'testforcapstone@gmail.com'
@@ -21,20 +23,48 @@ app.config['MAIL_PASSWORD'] = 'testemail'
 app.config['MAIL_USE_TLS'] = False
 app.config['MAIL_USE_SSL'] = True
 jwt = JWTManager(app)
-api = Api(app)
 mail.init_app(app)
+api = Api(
+    app,
+    version='test',
+    title='2021_2_backend API Server',
+    description='2021년 2학기 캡스톤디자인을 위한 API Server입니다.',
+    term_url="/",
+    contact="musichead99@naver.com"
+    )
 
 # request 유효성 체크 에러 메시지 처리
 @app.errorhandler(InvalidRequestError)
 def data_error(e):
     ReqErr = demo_error_formatter(e)[0]
 
-    return jsonify(ReqErr['errors']), 400
+    return jsonify({ "status" : "Failed", "message" : ReqErr['message']}), 400
 
 # jwt_required 에러 메시지 처리
 @jwt.unauthorized_loader
 def unauthorized_token_callback_test(jwt_payload):
-    return jsonify(message="Missing Authorization Header"), 401
+    return jsonify({"status" : "Failed", "message" : "Missing Authorization Header"}), 403
+
+# jwt_required에 blcoklist checking기능 추가
+@jwt.token_in_blocklist_loader
+def check_if_token_revoked(jwt_header, jwt_payload):
+    jti = jwt_payload["jti"]
+    db = database.DBClass()
+    query = '''
+        select * from revoked_tokens where jti=%s
+    '''
+    token = db.executeOne(query, (jti,))
+    return token is not None
+
+# 만료된 토큰으로 접근 시 반환할 메시지 처리
+@jwt.revoked_token_loader
+def revoked_token_response(jwt_header, jwt_payload):
+    return jsonify({"status" : "Failed", "message" : "Token has been revoked"}),400
+
+# 잘못된 메소드로 요청시 반환할 메시지 처리
+@api.errorhandler(werkzeug.exceptions.MethodNotAllowed)
+def not_allowd_method(e):
+    return {"status" : "Error", "message" : "The method is not allowed for the requested URL."},405
 
 # namespace 등록
 api.add_namespace(Test,'/')
@@ -45,4 +75,4 @@ api.add_namespace(Logout,'/user')
 api.add_namespace(Email,'/user')
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000)
+    app.run(host="0.0.0.0", port=5000, debug="true")

--- a/2021_2_backEnd/backEnd/user/login.py
+++ b/2021_2_backEnd/backEnd/user/login.py
@@ -27,9 +27,9 @@ class userLogin(Resource):
         # users 테이블에 일치하는 이메일과 비밀번호 한 쌍이 존재한다면 jwt토큰과 success메시지 반환
         if dbData is not None:
             return {
-                "message" : "Login Success",
+                "status" : "Success",
                 "access token" : create_access_token(identity = data['email'], expires_delta = False)
                 }, 200
         # 일치하는 이메일이 없을 경우에는 failed 메시지 반환
         else:
-            return {"message" : "Login Failed"}, 400
+            return {"status" : "Failed", "message" : "Cannot Login"}, 403

--- a/2021_2_backEnd/backEnd/user/logintest.py
+++ b/2021_2_backEnd/backEnd/user/logintest.py
@@ -20,4 +20,4 @@ class LGTest(Resource):
         if dbdata is None:
             return {"message":"user_only page, hello"}
         else:
-            return {"message" : "wrong token"}, 500
+            return {"message" : "wrong token"}, 403

--- a/2021_2_backEnd/backEnd/user/logout.py
+++ b/2021_2_backEnd/backEnd/user/logout.py
@@ -22,4 +22,4 @@ class userLogout(Resource):
         db.execute(query, (jti,))
         db.commit()
 
-        return {'message' : 'Logout Success'}
+        return {"status" : "Success"}

--- a/2021_2_backEnd/backEnd/user/register.py
+++ b/2021_2_backEnd/backEnd/user/register.py
@@ -1,15 +1,30 @@
 #register.py
 from flask import request
-from flask_restx import Namespace, Resource
+from flask_restx import Namespace, Resource, fields
 import database
 from pymysql import err
 from flask_request_validator import *
 
-Register = Namespace('Register')
+Register = Namespace(
+    name='Register',
+    description="회원가입을 위한 API"    
+)
+
+RegisterFields = Register.model('input_json_model', {
+    "email" : fields.String(description="your email", required=True, example="testemail@testdomain.com"),
+    "password" : fields.String(description="your password", required=True, example="testpw"),
+    "name" : fields.String(description="your name", required=True, example="testname")
+    })
+FailedModel = Register.model('return failed json model', {"message" : fields.String(description="Success or Failed", example="Register Failed(Email Duplicated)")})
+SuccessModel = Register.model('return succeed json model', {"message" : fields.String(description="Success or Failed", example="Register Success")})
 
 # 일반 이메일 회원가입 클래스
 @Register.route('/register')
+@Register.doc(params={"email" : "your email", "password" : "your password(영어+숫자+특수문자의 8자리 이상 20자리 미만)", "name" : "your name"})
 class register(Resource):
+    @Register.expect(RegisterFields)
+    @Register.response(201, 'Success', SuccessModel)
+    @Register.response(400, 'Failed', FailedModel)
     # request 유효성 검사
     @validate_params(
         Param('email', JSON, str, rules=[Pattern(r'^[\w+-_.]+@[\w-]+\.[a-zA-Z-.]+$')]),   # 이메일 형식 체크
@@ -18,6 +33,7 @@ class register(Resource):
     )
     # POST method로 'email', 'name', 'password' 필드를 가진 데이터를 body에 담아서 접근했을 때
     def post(self, *args):
+        """json객체로 보내진 email, name, password로 회원가입"""
         # json형식으로 data parsing, mysql connection을 위한 객체 생성
         data = request.json
         db = database.DBClass()
@@ -28,11 +44,8 @@ class register(Resource):
                 VALUES(%(email)s, %(password)s, %(name)s);
                 '''
             db.execute(query, data)
-            message = "Register Success"
-            code = 201
         except err.IntegrityError:
-            message = "Register Failed(Email Duplicated)"
-            code = 400
+            {"status": "Failed", "message" : "Email Duplicated" }, 400
         finally:
             db.commit()
-        return {"message": message }, code
+        return {"status": "Success" }, 201


### PR DESCRIPTION
1. register api의 문서 작성이 완료되었습니다. 서버를 열 시 http://baseurl/ 에서 확인 가능합니다.
2. mail 인증 api가 작성 완료되었습니다.
 - http://baseurl/user/email/"이메일주소"에 get method로 http통신을 하면 "이메일주소"가 현재 db의 user테이블에 존재하는지를 체크하고 결과를 리턴합니다.
3. 반환값들의 전체적인 형식을 수정했습니다.
 - {"status" : "", "message" : ""}의 형식으로 클라이언트에게 수행 결과를 반환합니다. 
 - status는 3종류로 Success, Failed, Error가 있습니다. 이 중 Failed와 Error시에는 message field가 객체에 포함되며 failed와 error의 이유를 설명합니다.
 - Success의 경우에는 message를 반환하지 않습니다.
4. error handler를 수정하여 대부분의 경우에는 위와 같은 형식으로 반환값을 리턴합니다.