### PR TITLE
 kakao 로그인 완료, jwt토큰 유효기간 설정, 만료된 토큰 처리하는 핸들러 설정

### DIFF
--- a/2021_2_backEnd/backEnd/__init__.py
+++ b/2021_2_backEnd/backEnd/__init__.py
@@ -1,5 +1,5 @@
 # __init__.py
-from flask import Flask, jsonify
+from flask import Flask
 from flask_restx import Api
 from flask_jwt_extended import JWTManager, exceptions
 from flask_request_validator.error_formatter import demo_error_formatter
@@ -9,7 +9,8 @@ from user.register import Register
 from user.logintest import LoginTest
 from user.mail import Email, mail
 from user.auth import Auth
-import database, werkzeug.exceptions
+from user.kakao import Kakao
+import database, werkzeug.exceptions, datetime
 
 app = Flask(__name__)
 app.config.update(JWT_SECRET_KEY = "backendTest") # jwt encoding을 위한 secret key, 추후 수정 필요
@@ -20,6 +21,7 @@ app.config['MAIL_USERNAME'] = 'testforcapstone@gmail.com'
 app.config['MAIL_PASSWORD'] = 'kklikhaaedpkyurm'
 app.config['MAIL_USE_TLS'] = False
 app.config['MAIL_USE_SSL'] = True
+app.config['JWT_ACCESS_TOKEN_EXPIRES'] = datetime.timedelta(days=10) # access token의 유효 기간 (10일)
 jwt = JWTManager(app)
 mail.init_app(app)
 api = Api(
@@ -43,7 +45,7 @@ def data_error(e):
 def unauthorized_token(e):
     return {"status" : "Failed", "message" : str(e)}, 403
 
-# jwt_required에 blcoklist checking기능 추가
+# jwt_required에 blocklist checking기능 추가
 @jwt.token_in_blocklist_loader
 def check_if_token_revoked(jwt_header, jwt_payload):
     jti = jwt_payload["jti"]
@@ -54,7 +56,12 @@ def check_if_token_revoked(jwt_header, jwt_payload):
     token = db.executeOne(query, (jti,))
     return token is not None
 
-# 만료된 토큰으로 접근 시 반환할 메시지 처리(추후 문제생길 가능성 있음;;)
+# 만료된 토큰으로 접근 시 반환할 메시지 처리
+@jwt.expired_token_loader
+def check_if_token_expired(jwt_header, jwt_payload):
+    return {"status" : "Failed"}, 403
+
+# 파기된 토큰으로 접근 시 반환할 메시지 처리(추후 문제생길 가능성 있음;;)
 @api.errorhandler(exceptions.RevokedTokenError)
 def revoked_token_response(e):
     return {"status" : "Failed", "message" : str(e)}, 400
@@ -70,7 +77,7 @@ api.add_namespace(Register,'/user')
 api.add_namespace(LoginTest,'/user')
 api.add_namespace(Email,'/user')
 api.add_namespace(Auth,'/user')
-
+api.add_namespace(Kakao,'/user/kakao')
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000, debug="true")

--- a/2021_2_backEnd/backEnd/user/auth.py
+++ b/2021_2_backEnd/backEnd/user/auth.py
@@ -1,3 +1,4 @@
+# auth.py
 from flask import request
 from flask_restx import Namespace, Resource, fields
 from flask_request_validator import *
@@ -59,7 +60,7 @@ class userAuth(Resource):
         if dbData is not None:
             return {
                 "status" : "Success",
-                "access token" : create_access_token(identity = data['email'], expires_delta = False)
+                "access token" : create_access_token(identity = data['email'])
                 }, 200
         # 일치하는 이메일이 없을 경우에는 failed 메시지 반환
         else:

--- a/2021_2_backEnd/backEnd/user/kakao.py
+++ b/2021_2_backEnd/backEnd/user/kakao.py
@@ -1,0 +1,84 @@
+#kakao.py
+from flask_restx import Namespace, Resource, fields
+from flask import request
+from flask_jwt_extended import create_access_token
+import requests, database
+
+Kakao = Namespace(name='Kakao', description="카카오 소셜 로그인을 위한 API")
+
+KakaoAuthSuccessModel = Kakao.model('4-1. kakao auth success model', {
+    "status" : fields.String(description="Success or Failed", example="Success"),
+    "link" : fields.String(description="link", example="https://kauth.kakao.com/oauth/authorize?client_id=b7f91f6772db2d633fb992e80d06827d&redirect_uri=http://182.212.194.105:5000/user/kakao/callback&response_type=code")
+    })
+
+KakaoAuthCallbackSuccessModel = Kakao.model('4-2. kakao auth callback success model', {
+    "status" : fields.String(description="Success or Failed", example="Success"),
+    "access token" : fields.String(description="access token", example="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmcmVzaCI6ZmFsc2UsImlhdCI6MTYzMDI4NzE3MiwianRpIjoiMjcwNjNjODctYWNhYS00NDJhLTk1M2UtMWM1MWQ3YmNjNTJkIiwidHlwZSI6ImFjY2VzcyIsInN1YiI6Imp1bnZlcnkyQG5hdmVyLmNvbSIsIm5iZiI6MTYzMDI4NzE3Mn0.QnyKfFmjHWNg6ShGsgRRawCzgWzoSDT3YjUzTtg2_Yg")
+    })
+
+KakaoAuthCallbackKeyErrorModel = Kakao.model('4-3 kakao auth callback keyerror model', {
+    "status" : fields.String(description="Success or Failed", example="Failed"),
+    "message" : fields.String(description="message", example="there's no key 'email'")
+    })
+
+@Kakao.route('/')
+class KakaoAuth(Resource):
+    @Kakao.response(200, 'Success', KakaoAuthSuccessModel)
+    def get(self):
+        '''해당 라우트로 클라이언트가 접속 시 카카오 로그인 페이지를 json객체에 담아 반환'''
+        clientID = 'b7f91f6772db2d633fb992e80d06827d'
+        redirectUri = 'http://182.212.194.105:5000/user/kakao/callback'
+        kakao_oauthurl = f"https://kauth.kakao.com/oauth/authorize?client_id={clientID}&redirect_uri={redirectUri}&response_type=code"
+
+        return {"status" : "Success", "link": kakao_oauthurl}, 200
+
+@Kakao.route('/callback')
+class KakaoAuthCallback(Resource):
+    @Kakao.response(200, 'Success', KakaoAuthCallbackSuccessModel)
+    @Kakao.response(400, 'Failed', KakaoAuthCallbackKeyErrorModel)
+    def get(self):
+        '''카카오 로그인 후 인증 코드를 받아 회원가입, 로그인 처리를 하는 콜백 함수'''
+        db = database.DBClass()
+
+        # 받은 인증 코드로 카카오에게 access token을 요청
+        authCode = request.args.get('code')
+        clientID = 'b7f91f6772db2d633fb992e80d06827d'
+        redirectUri = 'http://182.212.194.105:5000/user/kakao/callback'
+        token_request = requests.post(f"https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id={clientID}&redirect_uri={redirectUri}&code={authCode}")
+        token_request = token_request.json()
+
+        # 얻은 access token으로 다시 카카오에게 회원 정보 요청
+        try:
+            accessToken = token_request['access_token']
+
+            kakaoDataRequest = requests.get(
+                        "https://kapi.kakao.com/v2/user/me", headers={"Authorization" : f"Bearer {accessToken}"}
+                    )
+            kakaoDataRequest = kakaoDataRequest.json()
+
+            # 회원 정보 파싱
+            kakaoUserName = kakaoDataRequest['kakao_account']['profile']['nickname']
+            kakaoUserEmail = kakaoDataRequest['kakao_account']['email']
+        except KeyError as e:
+            return {"status" : "Failed", "message" : "There's no key " + str(e)}, 
+            
+        
+        # 현재 가입이 되어있는지 체크
+        query = '''
+            select * from users where email=(%s) and password=(%s);
+        '''
+        dbdata = db.executeOne(query, (kakaoUserEmail, "kakao"))
+
+        # 가입이 되어있지 않다면 db에 insert후 토큰 발급
+        if dbdata is None:
+            query='''
+                insert into users(email, password, name) values (%s, %s, %s);
+            '''
+            db.execute(query,(kakaoUserEmail, "kakao", kakaoUserName))
+            db.commit()
+        # 가입이 되어있다면 바로 토큰 발급
+        else:
+            return {"status" : "Success", "access token" : create_access_token(identity = dbdata['email'])}
+
+        return {"status" : "Success", "access token" : create_access_token(identity = kakaoUserEmail)}
+

--- a/2021_2_backEnd/backEnd/user/mail.py
+++ b/2021_2_backEnd/backEnd/user/mail.py
@@ -1,3 +1,5 @@
+# mail.py
+
 from flask import request
 from flask_restx import Namespace, Resource, fields
 from flask_request_validator import *

--- a/2021_2_backEnd/backEnd/user/register.py
+++ b/2021_2_backEnd/backEnd/user/register.py
@@ -1,4 +1,4 @@
-#register.py
+# register.py
 from flask import request
 from flask_jwt_extended.utils import get_jwt_identity, get_jwt
 from flask_restx import Namespace, Resource, fields
@@ -80,7 +80,7 @@ class register(Resource):
             return {"status": "Failed", "message" : "Email Duplicated"}, 400
         finally:
             db.commit()
-        return {"status": "Success" }, 201
+        return {"status": "Success"}, 201
 
     # 회원 탈퇴 API
     @Register.expect(parser)

--- a/2021_2_backEnd/backEnd/user/register.py
+++ b/2021_2_backEnd/backEnd/user/register.py
@@ -134,6 +134,6 @@ class register(Resource):
 
         if db.executeOne(query_list[0], data):
             db.execute_and_commit(query_list[1], data)
-            return {"status":"Success", "message":"The password has changed"},201
+            return {"status":"Success", "message":"The password has changed"},200
         else:
-             return {"status":"Failed", "message": "Wrong email"}, 400
+            return {"status":"Failed", "message": "Wrong email"}, 400

--- a/2021_2_backEnd/requirements.txt
+++ b/2021_2_backEnd/requirements.txt
@@ -3,7 +3,9 @@ aniso8601==9.0.1
 attrs==21.2.0
 bcrypt==3.2.0
 blinker==1.4
+certifi==2021.5.30
 cffi==1.14.6
+charset-normalizer==2.0.4
 click==8.0.1
 colorama==0.4.4
 Flask==2.0.1
@@ -15,6 +17,7 @@ flask-restx==0.5.0
 Flask-SQLAlchemy==2.5.1
 Flask-WTF==0.15.1
 greenlet==1.1.0
+idna==3.2
 itsdangerous==2.0.1
 Jinja2==3.0.1
 jsonschema==3.2.0
@@ -29,7 +32,9 @@ pyrsistent==0.18.0
 python-dateutil==2.8.2
 python-editor==1.0.4
 pytz==2021.1
+requests==2.26.0
 six==1.16.0
 SQLAlchemy==1.4.21
+urllib3==1.26.6
 Werkzeug==2.0.1
 WTForms==2.3.3


### PR DESCRIPTION
1. kakao 소셜 로그인 구현 완료
 - route : http://baseurl/user/kakao
2. 발급하는 jwt토큰의 유효기간 설정
 - 유효기간을 설정하지 않을 경우 토큰이 탈취당하면 개인정보 유출 위험성이 있음
 - 유효기간은 10일로 설정
3. 만료된 토큰으로 접근시 이를 block하고 처리하는 핸들러 작성
 - {"status" : "Failed"}를 반환
 - 아직 message는 설정하지 않음
