### PR TITLE
 profile route 작성, api문서 작성을 위한 model 분리, api문서 수정

### DIFF
--- a/2021_2_backEnd/.gitignore
+++ b/2021_2_backEnd/.gitignore
@@ -237,6 +237,7 @@ $RECYCLE.BIN/
 *.lnk
 
 *.png
+*.jpg
 
 # End of https://www.toptal.com/developers/gitignore/api/flask,python,windows
 

--- a/2021_2_backEnd/backEnd/__init__.py
+++ b/2021_2_backEnd/backEnd/__init__.py
@@ -11,6 +11,7 @@ from user.mail import Email, mail
 from user.auth import Auth
 from user.kakao import Kakao
 from user.naver import Naver
+from service.profile import Profile
 import database, swaggerModel, werkzeug.exceptions, datetime
 
 app = Flask(__name__)
@@ -73,6 +74,7 @@ def not_allowd_method(e):
     return {"status" : "Error", "message" : "The method is not allowed for the requested URL."}, 405
 
 # namespace 등록
+api.add_namespace(swaggerModel.SwaggerModel)
 api.add_namespace(Test,'/')
 api.add_namespace(Register,'/user')
 api.add_namespace(LoginTest,'/user')
@@ -80,7 +82,7 @@ api.add_namespace(Email,'/user')
 api.add_namespace(Auth,'/user')
 api.add_namespace(Kakao,'/user/kakao')
 api.add_namespace(Naver,'/user/Naver')
-api.add_namespace(swaggerModel.SwaggerModel)
+api.add_namespace(Profile,'/service')
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000, debug="true")

--- a/2021_2_backEnd/backEnd/__init__.py
+++ b/2021_2_backEnd/backEnd/__init__.py
@@ -11,7 +11,7 @@ from user.mail import Email, mail
 from user.auth import Auth
 from user.kakao import Kakao
 from user.naver import Naver
-import database, werkzeug.exceptions, datetime
+import database, swaggerModel, werkzeug.exceptions, datetime
 
 app = Flask(__name__)
 app.config.update(JWT_SECRET_KEY = "backendTest") # jwt encoding을 위한 secret key, 추후 수정 필요
@@ -80,6 +80,7 @@ api.add_namespace(Email,'/user')
 api.add_namespace(Auth,'/user')
 api.add_namespace(Kakao,'/user/kakao')
 api.add_namespace(Naver,'/user/Naver')
+api.add_namespace(swaggerModel.SwaggerModel)
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000, debug="true")

--- a/2021_2_backEnd/backEnd/service/profile.py
+++ b/2021_2_backEnd/backEnd/service/profile.py
@@ -1,0 +1,42 @@
+# profile.py
+
+from flask_restx import Resource, Namespace, fields
+from flask_jwt_extended import jwt_required
+from flask_request_validator import *
+import database, swaggerModel
+
+Profile = Namespace(name="Profile", description="프로필 정보를 처리하는 API")
+
+parser = Profile.parser()
+parser.add_argument('Authorization Header', location='headers')
+ProfileGetSuccessModel = Profile.inherit('5-1. Profile get success model', swaggerModel.BaseSuccessModel,{
+    "profile" : fields.Nested(swaggerModel.BaseProfileModel)
+})
+ProfileGetFailedModel = Profile.inherit('5-2. Profile get failed model', swaggerModel.BaseFailedModel, 
+    {"message" : fields.String(description="message", example="Email not registered")}
+)
+
+# 프로필 관련 요청을 처리하는 userProfile class
+@Profile.route('/<string:userEmail>')
+class userProfile(Resource):
+    @Profile.expect(parser)
+    @Profile.response(200, 'Success(프로필 정보 요청 성공)', ProfileGetSuccessModel)
+    @Profile.response(403, 'Failed(이메일이 가입되어 있지 않을)', ProfileGetFailedModel)
+    @validate_params (
+        Param('userEmail', PATH, str, rules=[Pattern(r'^[\w+-_.]+@[\w-]+\.[a-zA-Z-.]+$')])
+    )
+    @jwt_required()
+    def get(self, *args, **kwargs):
+        '''path로 전달된 이메일에 해당하는 프로필 정보를 클라이언트에 반환'''
+        userEmail = kwargs['userEmail']
+        db = database.DBClass()
+        query = '''
+            select name from users where email=(%s);
+        '''
+
+        profileData = db.executeOne(query,(userEmail,))
+            
+        if profileData is None:
+            return {"status" : "Failed", "message" : "Email not registered"}, 403
+        else:
+            return {"status" : "Success", "profile" : profileData}

--- a/2021_2_backEnd/backEnd/service/profile.py
+++ b/2021_2_backEnd/backEnd/service/profile.py
@@ -17,7 +17,7 @@ ProfileGetFailedModel = Profile.inherit('5-2. Profile get failed model', swagger
 )
 
 # 프로필 관련 요청을 처리하는 userProfile class
-@Profile.route('/<string:userEmail>')
+@Profile.route('/profile/<string:userEmail>')
 class userProfile(Resource):
     @Profile.expect(parser)
     @Profile.response(200, 'Success(프로필 정보 요청 성공)', ProfileGetSuccessModel)

--- a/2021_2_backEnd/backEnd/swaggerModel.py
+++ b/2021_2_backEnd/backEnd/swaggerModel.py
@@ -1,0 +1,40 @@
+# swaggerModel.py
+
+from flask_restx import fields, Model
+from flask_restx import Namespace
+
+SwaggerModel = Namespace('SwaggerModel')
+
+# base success or failed model
+BaseSuccessModel = SwaggerModel.model('Base Success Model', {
+    "status" : fields.String(description="Success or Failed", example="Success")
+})
+
+BaseFailedModel = SwaggerModel.model('Base Failed Model', {
+    "status" : fields.String(description="Success or Failed", example="Failed")
+})
+
+BaseProfileModel = SwaggerModel.model('Base Profile Model', {
+    "name" : fields.String(description="user name", example="testName")
+})
+
+# errorhandler에서 정의된 에러 return model
+NoAuthModel = SwaggerModel.inherit('No Auth Model', BaseFailedModel, {
+    "message" : fields.String(description="message", example="Missing Authorization Header")
+})
+
+RevokedTokenModel = SwaggerModel.inherit('Revoked Token Model', BaseFailedModel, {
+    "message" : fields.String(description="message", example="Token has been revoked")
+})
+
+ExpiredTokenModel = SwaggerModel.inherit('Expired Token Model', BaseFailedModel, {
+    "message" : fields.String(description="message", example="Token has expired")
+})
+
+MethodNotAllowedModel = SwaggerModel.inherit('Method Not Allowed Model', BaseFailedModel, {
+    "message" : fields.String(description="message", example="The method is not allowed for the requested URL.")
+})
+
+InvalidRequestModel = SwaggerModel.inherit('Invalid Request Error Model', BaseFailedModel, {
+    "message" : fields.String(description="message", example="invalid JSON parameters")
+})

--- a/2021_2_backEnd/backEnd/user/auth.py
+++ b/2021_2_backEnd/backEnd/user/auth.py
@@ -3,7 +3,7 @@ from flask import request
 from flask_restx import Namespace, Resource, fields
 from flask_request_validator import *
 from flask_jwt_extended import create_access_token, jwt_required, get_jwt
-import database
+import database, swaggerModel
 
 Auth = Namespace(
     name = 'Auth',
@@ -11,7 +11,7 @@ Auth = Namespace(
 )
 
 parser = Auth.parser()
-parser.add_argument('Authorization', location='headers')
+parser.add_argument('Authorization Header', location='headers')
 LoginFields = Auth.model('2-1 Login Request json model', {
     "email" : fields.String(description="your email", required=True, example="testemail@testdomain.com"),
     "password" : fields.String(description="your password", required=True, example="testpw")

--- a/2021_2_backEnd/backEnd/user/kakao.py
+++ b/2021_2_backEnd/backEnd/user/kakao.py
@@ -81,4 +81,3 @@ class KakaoAuthCallback(Resource):
             return {"status" : "Success", "access token" : create_access_token(identity = dbdata['email'])}
 
         return {"status" : "Success", "access token" : create_access_token(identity = kakaoUserEmail)}
-

--- a/2021_2_backEnd/backEnd/user/mail.py
+++ b/2021_2_backEnd/backEnd/user/mail.py
@@ -81,6 +81,6 @@ class emailAuth(Resource):
         data = db.executeOne(query,(userEmail,))
 
         if data is None:
-            return {"status":"Failed", "message": "Email not registered"}, 401
+            return {"status":"Failed", "message": "Email not registered"}, 403
         else:
             return {"status":"Success", "message":"The email registered"},200

--- a/2021_2_backEnd/backEnd/user/register.py
+++ b/2021_2_backEnd/backEnd/user/register.py
@@ -15,7 +15,7 @@ Register = Namespace(
 
 # API문서 작성을 위한 것들
 parser = Register.parser()
-parser.add_argument('Authorization', location='headers')
+parser.add_argument('Authorization Header', location='headers')
 RegisterFields = Register.model('1-1 Register Request json model', {
     "email" : fields.String(description="your email", required=True, example="testemail@testdomain.com"),
     "password" : fields.String(description="your password", required=True, example="testpw"),
@@ -106,7 +106,7 @@ class register(Resource):
         dbdata = dbdata['email']
 
         if dbdata is None:
-            return {"status":"Failed", "message": "The email could not be found. It doesn't seem to be registered."}, 401
+            return {"status":"Failed", "message": "The email could not be found. It doesn't seem to be registered."}, 403
         else:
             query = '''
                 DELETE FROM users WHERE email=(%s);
@@ -130,7 +130,7 @@ class register(Resource):
             "update users set password =%(new_password)s where email = %(email)s;"
             ]
         if request.json['new_password'] != request.json['new_password_again']:
-            return {"status":"Failed", "message": "The two passwords entered are different"}, 401
+            return {"status":"Failed", "message": "The two passwords entered are different"}, 40
 
         if db.executeOne(query_list[0], data):
             db.execute_and_commit(query_list[1], data)


### PR DESCRIPTION
1. profile api 작성 완료
 - 아직은 get method로 프로필 정보를 가져오는 기능만 구현
 - route : http://baseurl/service/profile/{userEmail}
 - 성공 시 return data 형식
{
    "status" : "Success",
    "profile" : {
                        "name" : "testName"
                    }
}
2. swagger작성을 좀 편하게 하기 위한 model객체들 분리
 - 자주 사용하는 모델들을 분리하여 제사용성을 높임
   ex) SuccessModel, FailedModel
 - swaggerModel.py에 model들 분리해서 보관
 - swagger작성 시 이 객체들을 상속해서 모델 만들면 됨
3. api문서 수정
 - header의 Authorization field 이름을 Authorization header로 바꿈(중요한거 x)