### PR TITLE
kakaoJWT_check 데코레이터 , 카카오톡친구목록 api , config.py 작성

### DIFF
--- a/2021_2_backEnd/backEnd/__init__.py
+++ b/2021_2_backEnd/backEnd/__init__.py
@@ -12,6 +12,7 @@ from user.auth import Auth
 from user.kakao import Kakao
 from user.naver import Naver
 from service.profile import Profile
+from service.kakaoFriendList import KakaoFriendList
 import database, swaggerModel, werkzeug.exceptions, datetime
 
 app = Flask(__name__)
@@ -83,6 +84,7 @@ api.add_namespace(Auth,'/user')
 api.add_namespace(Kakao,'/user/kakao')
 api.add_namespace(Naver,'/user/Naver')
 api.add_namespace(Profile,'/service')
+api.add_namespace(KakaoFriendList, '/service')
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000, debug="true")

--- a/2021_2_backEnd/backEnd/config.py
+++ b/2021_2_backEnd/backEnd/config.py
@@ -1,0 +1,5 @@
+# config.py
+# 여러 중요 정보들을 기록 #
+
+kakaoClientId = 'b7f91f6772db2d633fb992e80d06827d'
+baseUrl = 'http://182.212.194.105:5000'

--- a/2021_2_backEnd/backEnd/database.py
+++ b/2021_2_backEnd/backEnd/database.py
@@ -35,6 +35,10 @@ class DBClass():
     def commit(self):
         self.db.commit()
 
+    # close
+    def close(self):
+        self.db.close()
+
     # 쿼리작성시 바로 commit 
     def execute_and_commit(self, query, args={"a":"a"}):
         try:

--- a/2021_2_backEnd/backEnd/decorator.py
+++ b/2021_2_backEnd/backEnd/decorator.py
@@ -1,0 +1,52 @@
+# decorator.py
+
+from functools import wraps
+from datetime import datetime, timezone, timedelta
+import database, requests, config
+
+# 카카오톡 access token이 유효한지 확인하고 만료되었다면 재발급
+def kakaoJWT_check(func):
+    def wrapper(self, *args, **kwargs):
+
+        ClientID = config.kakaoClientId
+
+        # 인자로 전달받은 이메일이 존재하는지 체크
+        userEmail = kwargs['userEmail']
+        db = database.DBClass()
+        query = '''
+            select * from users where email = (%s);
+        '''
+        data = db.executeOne(query, (userEmail,))
+
+        if data is None :
+            return {"status" : "Failed", "message" : "Email not registered"}, 400
+        # 존재한다면 현재 카카오톡 access token이 유효한지 체크
+        else:
+            kakaoAccessTokenInfo = requests.get('https://kapi.kakao.com/v1/user/access_token_info', headers={"Authorization" : f"Bearer {data['kakaoAccessToken']}"})
+            
+            statusCode = kakaoAccessTokenInfo.status_code
+            tokenInfoDict = kakaoAccessTokenInfo.json()
+
+            # statusCode = 400 -> 문제 있음, 401 -> access token이 만료되었으므로 refresh token을 사용해 재발급, 200 -> 문제 없음
+            if statusCode == 400 :
+                return {"status" : "Failed", "message" : tokenInfoDict['msg']}, 400
+            elif statusCode == 401 :
+                token = data['kakaoRefreshToken']
+                refreshedData = requests.post(f'https://kauth.kakao.comc/oauth/token?grant_type=refresh_token&client_id={ClientID}&refresh_token={token}').json()
+
+                # refresh token의 유효 기간은 2달이고, 유효기간이 1달 미만으로 남을 때부터 같이 갱신 가능
+                if 'refresh_token' in refreshedData:
+                    query = '''
+                        update users set kakaoAccessToken=(%s), kakaoRefreshedToken=(%s) where email = (%s)
+                    '''
+                    inputList = (refreshedData['access_token'],refreshedData['refresh_token'], userEmail)
+                else:
+                    query = '''
+                        update users set kakaoAccessToken=(%s)where email = (%s)
+                    '''
+                    inputList = (refreshedData['access_token'], userEmail)
+                
+                db.execute(query,inputList)
+                db.close()
+        return func(self, *args, **kwargs)
+    return wrapper

--- a/2021_2_backEnd/backEnd/service/kakaoFriendList.py
+++ b/2021_2_backEnd/backEnd/service/kakaoFriendList.py
@@ -1,0 +1,31 @@
+# kakaoFriendList.py
+
+from flask_restx import Resource, Namespace
+from flask_jwt_extended import jwt_required
+from flask_request_validator import *
+import requests, database
+from decorator import kakaoJWT_check
+
+KakaoFriendList = Namespace("KakaoFiendList")
+
+# 카카오톡 친구목록 api
+@KakaoFriendList.route("/kakaoFriendList/<string:userEmail>")
+class UserKakaoFriendList(Resource):
+    @jwt_required()
+    @kakaoJWT_check # 카카오톡의 access token을 체크하는 데코레이터
+    @validate_params (
+        Param('userEmail', PATH, str, rules=[Pattern(r'^[\w+-_.]+@[\w-]+\.[a-zA-Z-.]+$')])
+    )
+    def get(self, *args, **kwargs):
+        userEmail = kwargs['userEmail']
+
+        db = database.DBClass()
+        query = '''
+            select * from users where email = (%s);
+        '''
+        accessToken = db.executeOne(query, (userEmail,))
+
+        userFriendList = requests.get("https://kapi.kakao.com/v1/api/talk/friends", headers={"Authorization" : f"Bearer {accessToken['kakaoAccessToken']}"}).json()
+        
+        db.close()
+        return userFriendList

--- a/2021_2_backEnd/backEnd/service/profile.py
+++ b/2021_2_backEnd/backEnd/service/profile.py
@@ -35,7 +35,7 @@ class userProfile(Resource):
         '''
 
         profileData = db.executeOne(query,(userEmail,))
-            
+        db.close()
         if profileData is None:
             return {"status" : "Failed", "message" : "Email not registered"}, 403
         else:

--- a/2021_2_backEnd/backEnd/user/auth.py
+++ b/2021_2_backEnd/backEnd/user/auth.py
@@ -55,6 +55,7 @@ class userAuth(Resource):
             SELECT * FROM users WHERE email=%(email)s AND password=%(password)s;
         '''
         dbData = db.executeOne(query, data)
+        db.close()
 
         # users 테이블에 일치하는 이메일과 비밀번호 한 쌍이 존재한다면 jwt토큰과 success메시지 반환
         if dbData is not None:

--- a/2021_2_backEnd/backEnd/user/kakao.py
+++ b/2021_2_backEnd/backEnd/user/kakao.py
@@ -2,7 +2,7 @@
 from flask_restx import Namespace, Resource, fields
 from flask import request
 from flask_jwt_extended import create_access_token
-import requests, database
+import requests, database, config
 
 Kakao = Namespace(name='Kakao', description="카카오 소셜 로그인을 위한 API")
 
@@ -26,9 +26,9 @@ class KakaoAuth(Resource):
     @Kakao.response(200, 'Success', KakaoAuthSuccessModel)
     def get(self):
         '''해당 라우트로 클라이언트가 접속 시 카카오 로그인 페이지를 json객체에 담아 반환'''
-        clientID = 'b7f91f6772db2d633fb992e80d06827d'
-        redirectUri = 'http://182.212.194.105:5000/user/kakao/callback'
-        kakao_oauthurl = f"https://kauth.kakao.com/oauth/authorize?client_id={clientID}&redirect_uri={redirectUri}&response_type=code"
+        clientID = config.kakaoClientId
+        redirectUri = config.baseUrl +'/user/kakao/callback'
+        kakao_oauthurl = f"https://kauth.kakao.com/oauth/authorize?client_id={clientID}&redirect_uri={redirectUri}&response_type=code&scope=friends"
 
         return {"status" : "Success", "link": kakao_oauthurl}, 200
 
@@ -42,14 +42,15 @@ class KakaoAuthCallback(Resource):
 
         # 받은 인증 코드로 카카오에게 access token을 요청
         authCode = request.args.get('code')
-        clientID = 'b7f91f6772db2d633fb992e80d06827d'
-        redirectUri = 'http://182.212.194.105:5000/user/kakao/callback'
+        clientID = config.kakaoClientId
+        redirectUri = config.baseUrl +'/user/kakao/callback'
         token_request = requests.post(f"https://kauth.kakao.com/oauth/token?grant_type=authorization_code&client_id={clientID}&redirect_uri={redirectUri}&code={authCode}")
         token_request = token_request.json()
 
         # 얻은 access token으로 다시 카카오에게 회원 정보 요청
         try:
             accessToken = token_request['access_token']
+            refreshToken = token_request['refresh_token']
 
             kakaoDataRequest = requests.get(
                         "https://kapi.kakao.com/v2/user/me", headers={"Authorization" : f"Bearer {accessToken}"}
@@ -72,12 +73,19 @@ class KakaoAuthCallback(Resource):
         # 가입이 되어있지 않다면 db에 insert후 토큰 발급
         if dbdata is None:
             query='''
-                insert into users(email, password, name) values (%s, %s, %s);
+                insert into users(email, password, name, kakaoAccessToken, kakaoRefreshToken) values (%s, %s, %s, %s, %s);
             '''
-            db.execute(query,(kakaoUserEmail, "kakao", kakaoUserName))
+            db.execute(query,(kakaoUserEmail, "kakao", kakaoUserName, accessToken, refreshToken))
             db.commit()
-        # 가입이 되어있다면 바로 토큰 발급
+            db.close()
+        # 가입이 되어있다면 카카오 엑세스 토큰을 갱신하고 바로 토큰 발급
         else:
+            query='''
+                update users set kakaoAccessToken=(%s) where email = (%s);
+            '''
+            db.execute(query,(accessToken, kakaoUserEmail))
+            db.commit()
+            db.close()
             return {"status" : "Success", "access token" : create_access_token(identity = dbdata['email'])}
 
         return {"status" : "Success", "access token" : create_access_token(identity = kakaoUserEmail)}

--- a/2021_2_backEnd/backEnd/user/logintest.py
+++ b/2021_2_backEnd/backEnd/user/logintest.py
@@ -16,7 +16,7 @@ class LGTest(Resource):
         jti = get_jwt()['jti']
 
         dbdata = db.executeOne(query, (jti,))
-
+        db.close()
         if dbdata is None:
             return {"message":"user_only page, hello"}
         else:

--- a/2021_2_backEnd/backEnd/user/mail.py
+++ b/2021_2_backEnd/backEnd/user/mail.py
@@ -79,7 +79,7 @@ class emailAuth(Resource):
                 select * from users where email=%s
             '''
         data = db.executeOne(query,(userEmail,))
-
+        db.close()
         if data is None:
             return {"status":"Failed", "message": "Email not registered"}, 403
         else:

--- a/2021_2_backEnd/backEnd/user/naver.py
+++ b/2021_2_backEnd/backEnd/user/naver.py
@@ -3,7 +3,7 @@ import re
 from flask_restx import Namespace, Resource, fields
 from flask import request
 from flask_jwt_extended import create_access_token
-import requests, database
+import requests, database, config
 
 Naver = Namespace(name='Naver', description="네이버 소셜 로그인을 위한 API")
 
@@ -28,7 +28,7 @@ class NaverAuth(Resource):
     def get(self):
         '''해당 라우트로 클라이언트가 접속 시 네이버 로그인 페이지를 json객체에 담아 반환'''
         clientID = 'f_nWrpPQdHxaUSGVuQZY'
-        redirectUri = 'http://172.23.14.215:5000/user/Naver/callback'
+        redirectUri = config.baseUrl + '/user/Naver/callback'
         Naver_oauthurl = f"https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id={clientID}&redirect_uri={redirectUri}&response_type=code"
 
         return {"status" : "Success", "link": Naver_oauthurl}, 200
@@ -45,7 +45,7 @@ class NaverAuthCallback(Resource):
         authCode = request.args.get('code')
         clientID = 'f_nWrpPQdHxaUSGVuQZY'
         client_secret= 'fXdLG082wS'
-        redirectUri = 'http://172.23.14.215:5000/user/Naver/callback'
+        redirectUri = config.baseUrl + '/user/Naver/callback'
         token_request = requests.post(f"https://nid.naver.com/oauth2.0/token?grant_type=authorization_code&client_id={clientID}&client_secret={client_secret}&redirect_uri={redirectUri}&code={authCode}&state={authCode}")
         token_request = token_request.json()
 
@@ -79,6 +79,7 @@ class NaverAuthCallback(Resource):
             '''
             db.execute(query,(NaverUserEmail, "Naver", NaverUserName))
             db.commit()
+            db.close()
         # # 가입이 되어있다면 바로 토큰 발급
         else:
             return {"status" : "Success", "access token" : create_access_token(identity = dbdata['email'])}

--- a/2021_2_backEnd/backEnd/user/register.py
+++ b/2021_2_backEnd/backEnd/user/register.py
@@ -80,6 +80,7 @@ class register(Resource):
             return {"status": "Failed", "message" : "Email Duplicated"}, 400
         finally:
             db.commit()
+            db.close()
         return {"status": "Success"}, 201
 
     # 회원 탈퇴 API
@@ -113,7 +114,7 @@ class register(Resource):
             '''
             db.execute(query, (dbdata,))
             db.commit()
-            return { "status" : "Success" }, 201
+            return { "status" : "Success" }, 200
     
     # 비밀번호 변경 API
     @Register.expect(ChangePW_Fileds)


### PR DESCRIPTION
1. kakaoJWT_check 데코레이터
 - 카카오톡이 제공하는 access token은 유효기간이 6시간이기 때문에 만료되었을시 갱신해주는 로직 필요
 - 이 데코레이터는 access token이 만료되었는지 체크하고 만료되었을 경우 refresh token을 이용해서 access token을 갱신함
 - 카카오톡 서비스 api를 이용할 때는 항상 @kakaoJWT_check 데코레이터 사용 바람
2. 카카오톡 친구목록 api
 - 작성은 완료했으나 카카오톡이 제공하는 정보가 많아서 회의를 통해 필요한 정보만을 추린 후 정보 파싱과 api문서 작업 예정
3. config.py작성
 - 코드상에서 대놓고 노출되면 안되는 정보들 ex) '카카오톡 앱 키' 들을 저장해놓을 파일
4. 그 외 잡다한 수정사항
 - db.close() 메소드 작성 : db connection을 닫는 함수, db연결 사용이 끝나면 항상 작성해주는게 맞을듯