### PR TITLE
api문서 작성 완료, user 테이블 column 변경, api 작성 및 수정

### DIFF
--- a/2021_2_backEnd/backEnd/__init__.py
+++ b/2021_2_backEnd/backEnd/__init__.py
@@ -15,6 +15,7 @@ from user.fcmToken import FcmToken
 from service.profile import Profile
 from service.friends import Friends
 from service.notification import Notification
+from service.image import Image
 
 import database, swaggerModel, werkzeug.exceptions, datetime
 
@@ -88,6 +89,7 @@ api.add_namespace(Profile,'/service')
 api.add_namespace(Friends, '/service')
 api.add_namespace(FcmToken, '/user')
 api.add_namespace(Notification, '/service')
+api.add_namespace(Image, '/service')
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000, debug="true")

--- a/2021_2_backEnd/backEnd/config.py
+++ b/2021_2_backEnd/backEnd/config.py
@@ -1,6 +1,9 @@
 # config.py
 # 여러 중요 정보들을 기록 #
+import os
+
+basePath = os.getcwd()
 
 kakaoClientId = 'b7f91f6772db2d633fb992e80d06827d'
-baseUrl = 'http://182.212.194.105:5000'
+baseUrl = 'http://180.80.221.11:5000'
 fcmServerKey = 'AAAApW2Mtew:APA91bFzpDeq2l13SgNXASSLxkh3ezZk4RyIGIxSa5uae0zjDiPuGynAtahcvL-ian73-kDg0j6Zjyr0pCj4noBf-_E4v_EZst5xqes9zf0aDNt9lxpZz0SQyFnw6n5jBLOmHYW2tKA4'

--- a/2021_2_backEnd/backEnd/service/image.py
+++ b/2021_2_backEnd/backEnd/service/image.py
@@ -1,0 +1,37 @@
+# image.py
+from flask import send_file
+from flask_restx import Namespace, Resource, fields
+from flask_jwt_extended import jwt_required
+import config, swaggerModel
+
+baseimagePath = config.basePath + '\\2021_2_backEnd\\backEnd\\images'
+
+Image = Namespace(name='Image', description='특정 이미지를 리턴하는 API')
+ImageGetFailedResponse = Image.inherit('Image get request model', swaggerModel.BaseFailedModel, {
+    "message" : fields.String(description="오류 메시지", example="'filename' is not exist")
+})
+parser = Image.parser()
+parser.add_argument('Authorization', location='headers', type=str, help='유저의 jwt토큰, 회원 인증에 사용된다.')
+
+@Image.route('/image/<string:fileName>')
+class AppImage(Resource):
+    @Image.expect(parser)
+    @Image.doc(params={'fileName' : '어떤 이미지 파일의 이름, 그 이미지 파일을 불러오기 위해 사용한다.'})
+    @Image.response(200, description='fileName으로 받은 파일 이름으로 이미지 반환')
+    @Image.response(400, description='Failed(인자로 받은 파일이름을 가진 이미지 파일이 존재하지 않을 경우)', model=ImageGetFailedResponse)
+    @Image.produces(['image/png', 'application/json'])
+    @Image.response(401, 
+    'Failed(jwt 토큰 관련 이슈)\nmessage : Missing Authorization Header(header에 jwt토큰이 존재하지 않을 때)\nmessage : Token has been revoked(토큰이 blocklist에 존재할 때)\nmessage : Token has expired(토큰이 만료되었을 때)',
+    swaggerModel.NoAuthModel
+    )
+    @jwt_required()
+    def get(self, *args, **kwargs):
+        '''특정 이미지 파일의 이름을 path에 인자로 받아 그 이미지를 반환한다.'''
+        fname = kwargs['fileName']
+
+        imagePath = baseimagePath + '\\' + fname
+
+        try:
+            return send_file(imagePath, mimetype='image/gif')
+        except FileNotFoundError:
+            return {"status" : "Failed", "message" : f"'{fname}' is not exist"}, 400

--- a/2021_2_backEnd/backEnd/service/notification.py
+++ b/2021_2_backEnd/backEnd/service/notification.py
@@ -1,25 +1,50 @@
 # notification.py
 from flask import request
-from flask_restx import Namespace, Resource
-from flask_jwt_extended import jwt_required
+from flask_restx import Namespace, Resource, fields
+from flask_jwt_extended import jwt_required, get_jwt_identity
 from flask_request_validator import *
 from pyfcm import FCMNotification
 import swaggerModel, config, database
 
-Notification = Namespace(name='Notification', description='한 클라이언트가 다른 클라이언트에게 푸시 알람을 보낼 수 있도록 해 주는 API')
+Notification = Namespace(name='Notification', description='푸시 알람 기능을 처리하는 API')
 push_service = FCMNotification(config.fcmServerKey)
+
+parser = Notification.parser()
+parser.add_argument('Authorization', location='headers', type=str, help='유저의 jwt토큰, 회원 인증에 사용된다.')
+NotificationPostRequest = Notification.model('notification request model', {
+    "receiver" : fields.String(description="메시지를 받을 유저의 이메일", required=True, example="testemail@testdomain.com"),
+    "title" : fields.String(description="메시지의 타이틀", required=True, example="test message title"),
+    "body" : fields.String(description="메시지의 내용", required=True, example="test message body")
+})
+NotificationPostFailedResponse = Notification.inherit('notification failed response model', swaggerModel.BaseFailedModel, {
+    "message" : fields.String(description="오류 메시지", example="There's no fcm token")
+})
 
 # 미완성
 @Notification.route('/notification')
+@Notification.response(401, 
+    'Failed(jwt 토큰 관련 이슈)\nmessage : Missing Authorization Header(header에 jwt토큰이 존재하지 않을 때)\nmessage : Token has been revoked(토큰이 blocklist에 존재할 때)\nmessage : Token has expired(토큰이 만료되었을 때)',
+    swaggerModel.NoAuthModel
+    )
+@Notification.response(500, 'Failed(서버 관련 이슈)', swaggerModel.InternalServerErrorModel)
 class AppNotification(Resource):
+    @Notification.expect(parser, NotificationPostRequest)
+    @Notification.response(200, 'Sucess', swaggerModel.BaseSuccessModel)
+    @Notification.response(400, 'Failed(메시지를 받을 유저의 fcmToken이 존재하지 않을 경우)', NotificationPostFailedResponse)
+    @jwt_required()
     def post(self, *args):
-        userEmail = 'rdd0426@gmail.com'
+        '''클라이언트로부터 푸시 메시지를 받을 유저의 정보와 푸시 메시지를 받아 전송하고 결과를 반환한다.'''
         data = request.json
+        userEmail = data['receiver']
         db = database.DBClass()
         query = '''
             select * from users where email=(%s);
         '''
         token = db.executeOne(query,(userEmail,))['fcmToken']
+
+        # 메시지를 받을 유저의 fcmToken이 존재하지 않을 때
+        if token is None:
+            return {'status' : 'Failed', 'message' : 'There''s no fcm token'}, 400
 
         result = push_service.notify_single_device(registration_id=token, message_title=data['title'], message_body=data['body'], data_message=data)
 

--- a/2021_2_backEnd/backEnd/service/profile.py
+++ b/2021_2_backEnd/backEnd/service/profile.py
@@ -2,57 +2,62 @@
 
 from flask import request
 from flask_restx import Resource, Namespace, fields
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import jwt_required, get_jwt_identity
 from flask_request_validator import *
-import database, swaggerModel
+import database, swaggerModel, config
 
 Profile = Namespace(name="Profile", description="프로필 정보를 처리하는 API")
 
 parser = Profile.parser()
-parser.add_argument('Authorization Header', location='headers', type=str, help='회원 인증용 jwt토큰')
-ProfileGetSuccessModel = Profile.inherit('5-1. Profile get success model', swaggerModel.BaseSuccessModel,{
+parser.add_argument('Authorization', location='headers', type=str, help='유저의 jwt토큰, 회원 인증에 사용된다.')
+ProfileGetSuccessResponse = Profile.inherit('5-1. Profile get success response model', swaggerModel.BaseSuccessModel,{
     "profile" : fields.Nested(swaggerModel.BaseProfileModel)
 })
-ProfileGetFailedModel = Profile.inherit('5-2. Profile get/put failed model', swaggerModel.BaseFailedModel, 
-    {"message" : fields.String(description="message", example="Email not registered")}
+ProfileGetFailedResponse = Profile.inherit('5-2. Profile get/put failed response model', swaggerModel.BaseFailedModel, 
+    {"message" : fields.String(description="오류 메시지", example="Email not registered")}
 )
 
 # 프로필 관련 요청을 처리하는 userProfile class
-@Profile.route('/profile/<string:userEmail>')
-@Profile.doc(params={'userEmail' : '사용자의 이메일'})
+@Profile.route('/profile')
+@Profile.response(401, 
+    'Failed(jwt 토큰 관련 이슈)\nmessage : Missing Authorization Header(header에 jwt토큰이 존재하지 않을 때)\nmessage : Token has been revoked(토큰이 blocklist에 존재할 때)\nmessage : Token has expired(토큰이 만료되었을 때)',
+    swaggerModel.NoAuthModel
+    )
+@Profile.response(500, 'Failed(서버 관련 이슈)', swaggerModel.InternalServerErrorModel)
 class userProfile(Resource):
     @Profile.expect(parser)
-    @Profile.response(200, 'Success(프로필 정보 요청 성공)', ProfileGetSuccessModel)
-    @Profile.response(401, 'Failed(이메일이 가입되어 있지 않을)', ProfileGetFailedModel)
-    @validate_params (
-        Param('userEmail', PATH, str, rules=[Pattern(r'^[\w+-_.]+@[\w-]+\.[a-zA-Z-.]+$')])
-    )
+    @Profile.response(200, 'Success(프로필 정보 요청 성공)', ProfileGetSuccessResponse)
+    @Profile.response(400, 'Failed(유저가 가입되어 있지 않을 경우)', ProfileGetFailedResponse)
     @jwt_required()
-    def get(self, *args, **kwargs):
-        '''path로 전달된 이메일에 해당하는 프로필 정보를 클라이언트에 반환'''
-        userEmail = kwargs['userEmail']
+    def get(self):
+        '''클라이언트로부터 받은 jwt토큰에서 이메일을 분리하여 해당하는 프로필 정보를 반환한다.'''
+        userEmail = get_jwt_identity()
         db = database.DBClass()
         query = '''
-            select name from users where email=(%s);
+            select name, profilePhoto from users where email=(%s);
         '''
 
         profileData = db.executeOne(query,(userEmail,))
         db.close()
+
+        if profileData['profilePhoto'] is None:
+            profileData['profilePhoto'] = config.baseUrl + '/service/image/default_profile.jpg'
+
         if profileData is None:
-            return {"status" : "Failed", "message" : "Email not registered"}, 401
+            return {"status" : "Failed", "message" : "Email not registered"}, 400
         else:
             return {"status" : "Success", "profile" : profileData}
     
     @validate_params (
-        Param('userEmail', PATH, str, rules=[Pattern(r'^[\w+-_.]+@[\w-]+\.[a-zA-Z-.]+$')]),
-        Param('name', JSON, str, required=False, rules=CompositeRule(Pattern(r'[a-zA-Z가-힣]'), MinLength(1))),   
-        Param('profilePhoto', JSON, str, required=False, rules=[MinLength(1)])
+        Param('name', JSON, str, required=False, rules=CompositeRule(Pattern(r'[a-zA-Z가-힣]'), MinLength(1)))  
     )
     @jwt_required()
     @Profile.expect(swaggerModel.BaseProfileModel)
-    @Profile.response(200, '(Success)프로필 정보 변경 성공', swaggerModel.BaseSuccessModel)
-    def put(self, *args, **kwargs):
-        userEmail = kwargs['userEmail']
+    @Profile.response(200, 'Success(프로필 정보 변경 성공)', swaggerModel.BaseSuccessModel)
+    @Profile.response(400, 'Failed(유저가 가입되어 있지 않을 경우)', ProfileGetFailedResponse)
+    def put(self, *args):
+        '''클라이언트로 받은 프로필 정보들로 현재 프로필 정보를 갱신하고 결과를 반환한다.'''
+        userEmail = get_jwt_identity()
         data = request.json
         db = database.DBClass()
 
@@ -61,7 +66,7 @@ class userProfile(Resource):
                 select from users where email = %s
             '''
         if db.executeOne(query, (userEmail,)) is None:
-            return {"status":"Failed", "message": "Email not registered"}, 401
+            return {"status":"Failed", "message": "Email not registered"}, 400
 
         # 각 파라미터별로 DB에 갱신
         if 'name' in data :

--- a/2021_2_backEnd/backEnd/swaggerModel.py
+++ b/2021_2_backEnd/backEnd/swaggerModel.py
@@ -1,7 +1,6 @@
 # swaggerModel.py
 
-from flask_restx import fields, Model
-from flask_restx import Namespace
+from flask_restx import Namespace, fields
 
 SwaggerModel = Namespace('SwaggerModel')
 
@@ -15,27 +14,30 @@ BaseFailedModel = SwaggerModel.model('Base Failed Model', {
 })
 
 BaseProfileModel = SwaggerModel.model('Base Profile Model', {
-    "name" : fields.String(description="user name", example="testName"),
-    "profilePhoto" : fields.String(description="your profilePhoto", example="(imagefile with base64 Encoded code)")
+    "name" : fields.String(description="유저의 이름", example="testName"),
 })
 
 # errorhandler에서 정의된 에러 return model
 NoAuthModel = SwaggerModel.inherit('No Auth Model', BaseFailedModel, {
-    "message" : fields.String(description="message", example="Missing Authorization Header")
+    "message" : fields.String(description="오류 메시지", example="Missing Authorization Header")
 })
 
 RevokedTokenModel = SwaggerModel.inherit('Revoked Token Model', BaseFailedModel, {
-    "message" : fields.String(description="message", example="Token has been revoked")
+    "message" : fields.String(description="오류 메시지", example="Token has been revoked")
 })
 
 ExpiredTokenModel = SwaggerModel.inherit('Expired Token Model', BaseFailedModel, {
-    "message" : fields.String(description="message", example="Token has expired")
+    "message" : fields.String(description="오류 메시지", example="Token has expired")
 })
 
 MethodNotAllowedModel = SwaggerModel.inherit('Method Not Allowed Model', BaseFailedModel, {
-    "message" : fields.String(description="message", example="The method is not allowed for the requested URL.")
+    "message" : fields.String(description="오류 메시지", example="The method is not allowed for the requested URL.")
+})
+
+InternalServerErrorModel = SwaggerModel.inherit('Internal Server Error Model', BaseFailedModel, {
+    "message" : fields.String(description="오류 메시지", example="Internal Server Error")
 })
 
 InvalidRequestModel = SwaggerModel.inherit('Invalid Request Error Model', BaseFailedModel, {
-    "message" : fields.String(description="message", example="invalid JSON parameters")
+    "message" : fields.String(description="오류 메시지", example="invalid JSON parameters")
 })

--- a/2021_2_backEnd/backEnd/user/auth.py
+++ b/2021_2_backEnd/backEnd/user/auth.py
@@ -7,47 +7,35 @@ import database, swaggerModel
 
 Auth = Namespace(
     name = 'Auth',
-    description="로그인/아웃을 위한 API"
+    description="로그인/아웃을 처리하는 API"
 )
 
 parser = Auth.parser()
-parser.add_argument('Authorization Header', location='headers')
-LoginFields = Auth.model('2-1 Login Request json model', {
-    "email" : fields.String(description="your email", required=True, example="testemail@testdomain.com"),
-    "password" : fields.String(description="your password", required=True, example="testpw")
+parser.add_argument('Authorization', location='headers', type=str, help='유저의 jwt토큰, 회원 인증에 사용된다.')
+AuthPostRequest = Auth.model('2-1 Login Request json model', {
+    "email" : fields.String(description="유저의 이메일", required=True, example="testemail@testdomain.com"),
+    "password" : fields.String(description="유저의 비밀번호", required=True, example="testpw123!")
 })
-FailedModel = Auth.model('2-2 Failed json model', {
-    "status" : fields.String(description="Success or Failed", example="Failed")
+AuthFailedModel = Auth.inherit('2-5. Login Failed json model', swaggerModel.BaseFailedModel, {
+    "message" : fields.String(description="에러 메시지", example="Cannot Login")
 })
-SuccessModel = Auth.model('2-3 Success json model', {
-    "status" : fields.String(description="Success or Failed", example="Success"),
-})
-LoginFailedModel = Auth.inherit('2-5. Login Failed json model', FailedModel, {
-    "message" : fields.String(description="message", example="Cannot Login")
-})
-LoginSuccessModel = Auth.inherit('2-6. Login Success json model', SuccessModel,{
-    "access token" : fields.String(description="Token", example="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmcmVzaCI6ZmFsc2UsImlhdCI6MTYzMDI4NzE3MiwianRpIjoiMjcwNjNjODctYWNhYS00NDJhLTk1M2UtMWM1MWQ3YmNjNTJkIiwidHlwZSI6ImFjY2VzcyIsInN1YiI6Imp1bnZlcnkyQG5hdmVyLmNvbSIsIm5iZiI6MTYzMDI4NzE3Mn0.QnyKfFmjHWNg6ShGsgRRawCzgWzoSDT3YjUzTtg2_Yg"),
-})
-LogoutNoAuthModel = Auth.inherit('2-7. Logout Authorization Failed json model', FailedModel, {
-    "message" : fields.String(description="message", example="Missing Authorization Header")
-})
-LogoutRevokedTokenModel = Auth.inherit('2-8. Logout Revocked token json model', FailedModel, {
-    "message" : fields.String(description="message", example="Token has been revoked")
+AuthSuccessModel = Auth.inherit('2-6. Login Success json model', swaggerModel.BaseSuccessModel,{
+    "access token" : fields.String(description="access jwt token", example="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmcmVzaCI6ZmFsc2UsImlhdCI6MTYzMDI4NzE3MiwianRpIjoiMjcwNjNjODctYWNhYS00NDJhLTk1M2UtMWM1MWQ3YmNjNTJkIiwidHlwZSI6ImFjY2VzcyIsInN1YiI6Imp1bnZlcnkyQG5hdmVyLmNvbSIsIm5iZiI6MTYzMDI4NzE3Mn0.QnyKfFmjHWNg6ShGsgRRawCzgWzoSDT3YjUzTtg2_Yg"),
 })
 
 # userAuth 클래스, 로그인과 로그아웃기능을 함
 @Auth.route('/auth')
+@Auth.response(500, 'Failed(서버 관련 이슈)', swaggerModel.InternalServerErrorModel)
 class userAuth(Resource): 
-    @Auth.doc(params={'email' : "your email", "password": "your password"})
-    @Auth.expect(LoginFields)
-    @Auth.response(200, 'Success', LoginSuccessModel)
-    @Auth.response(400, 'Failed', LoginFailedModel)   
+    @Auth.expect(AuthPostRequest)
+    @Auth.response(200, 'Success (access용 jwt 토큰을 반환한다. 유효기간은 10일)', AuthSuccessModel)
+    @Auth.response(400, 'Failed (일치하는 회원 정보가 없어 로그인에 실패했을 경우)', AuthFailedModel)   
     @validate_params(
         Param('email', JSON, str, rules=[Pattern(r'^[\w+-_.]+@[\w-]+\.[a-zA-Z-.]+$')]),   # 이메일 형식 체크
         Param('password', JSON, str, rules=CompositeRule(Pattern(r'(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[^\w\s]).*'), MinLength(8), MaxLength(20))),   # 비밀번호 형식 체크(한, 영, 숫자, 특수문자 포함)
     )
     def post(self, *args):
-        """json형식으로 전달받은 email, password로 로그인"""
+        """클라이언트로부터 유저의 로그인 정보를 받아서 access용 jwt 토큰을 반환한다."""
         # json형식으로 data parsing, mysql connection을 위한 객체 생성
         data = request.json
         db = database.DBClass()
@@ -65,16 +53,18 @@ class userAuth(Resource):
                 }, 200
         # 일치하는 이메일이 없을 경우에는 failed 메시지 반환
         else:
-            return {"status" : "Failed", "message" : "Cannot Login"}, 401
+            return {"status" : "Failed", "message" : "Cannot Login"}, 400
 
-    @jwt_required()
     @Auth.expect(parser)
-    @Auth.response(401, 'Failed ( 이미 blocklist에 등록된 토큰일 때 )', LogoutRevokedTokenModel)
-    @Auth.response(401, 'Failed ( header에 jwt토큰이 존재하지 않을 때 )', LogoutNoAuthModel)
-    @Auth.response(200, 'Success',SuccessModel)
+    @Auth.response(200, 'Success', swaggerModel.BaseSuccessModel)
+    @Auth.response(401, 
+    'Failed(jwt 토큰 관련 이슈)\nmessage : Missing Authorization Header(header에 jwt토큰이 존재하지 않을 때)\nmessage : Token has been revoked(토큰이 blocklist에 존재할 때)\nmessage : Token has expired(토큰이 만료되었을 때)',
+    swaggerModel.NoAuthModel
+    )
+    @jwt_required()
     # DELETE method로 url에 접근했을 때
     def delete(self):
-        """header의 Authorization fields에 JWT토큰을 포함해서 요청하면 해당 토큰을 blocklist에 등록한다."""
+        """클라이언트로부터 받은 jwt토큰을 blocklist에 등록해 로그아웃 처리를 한다."""
         # 받은 request의 header에서 jwt토큰을 분리해서 DB의 블랙리스트 테이블(revoked_tokens)에 등록한다.
         jti = get_jwt()['jti']
         db = database.DBClass()

--- a/2021_2_backEnd/backEnd/user/fcmToken.py
+++ b/2021_2_backEnd/backEnd/user/fcmToken.py
@@ -1,16 +1,38 @@
-from flask_restx import Resource, Namespace
+from flask_restx import Resource, Namespace, fields
+from flask_jwt_extended import jwt_required, get_jwt_identity
 from flask import request
-import database
+import database, swaggerModel
 
-FcmToken = Namespace('FcmToken')
+FcmToken = Namespace(name='FcmToken', description='푸시 알림 기능을 사용하기 위해 클라이언트의 fcm token을 저장하는 API')
+
+FcmTokenPostRequest = FcmToken.model('fcm token post request model', {
+    'token' : fields.String(description='fcm 토큰', example='{some exmaple fcm token}')
+})
+FcmTokenPostFailedResponse = FcmToken.inherit('fcm token post failed response model', swaggerModel.BaseFailedModel, {
+    'message' : fields.String(description='오류 메시지', example='Email not registered')
+})
 
 # 미완성
 @FcmToken.route('/fcmToken')
 class AppFcmToken(Resource):
+    @FcmToken.expect(FcmTokenPostRequest)
+    @FcmToken.response(200, 'Success', swaggerModel.BaseSuccessModel)
+    @FcmToken.response(400, 'Failed(유저가 가입되어 있지 않을 경우)', FcmTokenPostFailedResponse)
+    @FcmToken.response(401, 
+    'Failed(jwt 토큰 관련 이슈)\nmessage : Missing Authorization Header(header에 jwt토큰이 존재하지 않을 때)\nmessage : Token has been revoked(토큰이 blocklist에 존재할 때)\nmessage : Token has expired(토큰이 만료되었을 때)',
+    swaggerModel.NoAuthModel
+    )
+    @jwt_required()
     def post(self):
+        '''클라이언트로부터 fcm token을 받아 DB에 저장하고 결과를 반환한다.'''
         data = request.json['token']
-        userEmail = 'rdd0426@gmail.com'
+        userEmail = get_jwt_identity()
         db = database.DBClass()
+        query = '''
+            select * from users where email = (%s);
+        '''
+        if db.execute(query, (userEmail,)) is None:
+            return {'status' : 'Failed', 'message' : 'Email not registered'}, 400
 
         query = '''
             update users set fcmToken=(%s) where email=(%s);

--- a/2021_2_backEnd/backEnd/user/kakao.py
+++ b/2021_2_backEnd/backEnd/user/kakao.py
@@ -2,42 +2,41 @@
 from flask_restx import Namespace, Resource, fields
 from flask import request
 from flask_jwt_extended import create_access_token
-import requests, database, config
+import requests, database, config, swaggerModel
 
-Kakao = Namespace(name='Kakao', description="카카오 소셜 로그인을 위한 API")
+Kakao = Namespace(name='Kakao', description="카카오 소셜 로그인을 처리하는 API")
 
-KakaoAuthSuccessModel = Kakao.model('4-1. kakao auth success model', {
-    "status" : fields.String(description="Success or Failed", example="Success"),
+KakaoAuthGetSuccessResponse = Kakao.inherit('4-1 kakao auth success model', swaggerModel.BaseSuccessModel, {
     "link" : fields.String(description="link", example="https://kauth.kakao.com/oauth/authorize?client_id=b7f91f6772db2d633fb992e80d06827d&redirect_uri=http://182.212.194.105:5000/user/kakao/callback&response_type=code")
     })
 
-KakaoAuthCallbackSuccessModel = Kakao.model('4-2. kakao auth callback success model', {
-    "status" : fields.String(description="Success or Failed", example="Success"),
-    "access token" : fields.String(description="access token", example="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmcmVzaCI6ZmFsc2UsImlhdCI6MTYzMDI4NzE3MiwianRpIjoiMjcwNjNjODctYWNhYS00NDJhLTk1M2UtMWM1MWQ3YmNjNTJkIiwidHlwZSI6ImFjY2VzcyIsInN1YiI6Imp1bnZlcnkyQG5hdmVyLmNvbSIsIm5iZiI6MTYzMDI4NzE3Mn0.QnyKfFmjHWNg6ShGsgRRawCzgWzoSDT3YjUzTtg2_Yg")
+KakaoAuthCallbackSuccessResponse = Kakao.inherit('4-2 kakao auth callback success model', swaggerModel.BaseSuccessModel, {
+    "access token" : fields.String(description="access jwt token", example="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmcmVzaCI6ZmFsc2UsImlhdCI6MTYzMDI4NzE3MiwianRpIjoiMjcwNjNjODctYWNhYS00NDJhLTk1M2UtMWM1MWQ3YmNjNTJkIiwidHlwZSI6ImFjY2VzcyIsInN1YiI6Imp1bnZlcnkyQG5hdmVyLmNvbSIsIm5iZiI6MTYzMDI4NzE3Mn0.QnyKfFmjHWNg6ShGsgRRawCzgWzoSDT3YjUzTtg2_Yg")
     })
 
-KakaoAuthCallbackKeyErrorModel = Kakao.model('4-3 kakao auth callback keyerror model', {
-    "status" : fields.String(description="Success or Failed", example="Failed"),
-    "message" : fields.String(description="message", example="there's no key 'email'")
+KakaoAuthCallbackKeyErrorResponse = Kakao.inherit('4-3 kakao auth callback keyerror model', swaggerModel.BaseFailedModel, {
+    "message" : fields.String(description="오류 메시지", example="there's no key 'access_token'")
     })
 
 @Kakao.route('/')
+@Kakao.response(500, 'Failed(서버 관련 이슈)', swaggerModel.InternalServerErrorModel)
 class KakaoAuth(Resource):
-    @Kakao.response(200, 'Success', KakaoAuthSuccessModel)
+    @Kakao.response(200, 'Success', KakaoAuthGetSuccessResponse)
     def get(self):
-        '''해당 라우트로 클라이언트가 접속 시 카카오 로그인 페이지를 json객체에 담아 반환'''
+        '''클라이언트가 접속 시 카카오 로그인 페이지 링크를 반환한다.'''
         clientID = config.kakaoClientId
         redirectUri = config.baseUrl +'/user/kakao/callback'
-        kakao_oauthurl = f"https://kauth.kakao.com/oauth/authorize?client_id={clientID}&redirect_uri={redirectUri}&response_type=code&scope=friends"
+        kakao_oauthurl = f"https://kauth.kakao.com/oauth/authorize?client_id={clientID}&redirect_uri={redirectUri}&response_type=code"
 
         return {"status" : "Success", "link": kakao_oauthurl}, 200
 
 @Kakao.route('/callback')
+@Kakao.response(500, 'Failed(서버 관련 이슈)', swaggerModel.InternalServerErrorModel)
 class KakaoAuthCallback(Resource):
-    @Kakao.response(200, 'Success', KakaoAuthCallbackSuccessModel)
-    @Kakao.response(400, 'Failed', KakaoAuthCallbackKeyErrorModel)
+    @Kakao.response(200, 'Success', KakaoAuthCallbackSuccessResponse)
+    @Kakao.response(400, 'Failed( 카카오로부터 받은 response에 특정 key들이 존재하지 않을 경우 )', KakaoAuthCallbackKeyErrorResponse)
     def get(self):
-        '''카카오 로그인 후 인증 코드를 받아 회원가입, 로그인 처리를 하는 콜백 함수'''
+        '''카카오로부터 인증 코드를 받아 회원가입, 로그인 처리를 하고 access용 jwt 토큰을 반환한다.'''
         db = database.DBClass()
 
         # 받은 인증 코드로 카카오에게 access token을 요청
@@ -50,8 +49,7 @@ class KakaoAuthCallback(Resource):
         # 얻은 access token으로 다시 카카오에게 회원 정보 요청
         try:
             accessToken = token_request['access_token']
-            refreshToken = token_request['refresh_token']
-
+            print(accessToken)
             kakaoDataRequest = requests.get(
                         "https://kapi.kakao.com/v2/user/me", headers={"Authorization" : f"Bearer {accessToken}"}
                     )
@@ -60,6 +58,10 @@ class KakaoAuthCallback(Resource):
             # 회원 정보 파싱
             kakaoUserName = kakaoDataRequest['kakao_account']['profile']['nickname']
             kakaoUserEmail = kakaoDataRequest['kakao_account']['email']
+            if kakaoDataRequest['kakao_account']['profile']['is_default_image'] is False: 
+                kakaoUserPhoto = kakaoDataRequest['kakao_account']['profile']['profile_image_url']
+            else:
+                kakaoUserPhoto = None
         except KeyError as e:
             return {"status" : "Failed", "message" : "There's no key " + str(e)}, 
             
@@ -73,9 +75,9 @@ class KakaoAuthCallback(Resource):
         # 가입이 되어있지 않다면 db에 insert후 토큰 발급
         if dbdata is None:
             query='''
-                insert into users(email, password, name, kakaoAccessToken, kakaoRefreshToken) values (%s, %s, %s, %s, %s);
+                insert into users(email, password, name, profilePhoto) values (%s, %s, %s, %s);
             '''
-            db.execute(query,(kakaoUserEmail, "kakao", kakaoUserName, accessToken, refreshToken))
+            db.execute(query,(kakaoUserEmail, "kakao", kakaoUserName, kakaoUserPhoto))
             db.commit()
             db.close()
         # 가입이 되어있다면 카카오 엑세스 토큰을 갱신하고 바로 토큰 발급

--- a/2021_2_backEnd/backEnd/user/register.py
+++ b/2021_2_backEnd/backEnd/user/register.py
@@ -2,61 +2,50 @@
 from flask import request
 from flask_jwt_extended.utils import get_jwt_identity, get_jwt
 from flask_restx import Namespace, Resource, fields
-import database
+import database, swaggerModel
 from pymysql import err
 from flask_request_validator import *
 from flask_jwt_extended import jwt_required
 
 Register = Namespace(
     name='Register',
-    description="회원가입/탈퇴를 위한 API"    
+    description="회원가입/탈퇴, 비밀번호 변경을 처리하는 API"    
 )
-
 
 # API문서 작성을 위한 것들
 parser = Register.parser()
-parser.add_argument('Authorization Header', location='headers')
-RegisterFields = Register.model('1-1 Register Request json model', {
-    "email" : fields.String(description="your email", required=True, example="testemail@testdomain.com"),
-    "password" : fields.String(description="your password", required=True, example="testpw"),
-    "name" : fields.String(description="your name", required=True, example="testname")
+parser.add_argument('Authorization', location='headers', help='사용자의 jwt토큰, 회원 인증에 사용된다.')
+RegisterPostRequest = Register.model('1-1 Register Request model', {
+    "email" : fields.String(description="유저의 이메일", required=True, example="testemail@testdomain.com", help='testpw123!'),
+    "password" : fields.String(description="유저의 비밀번호", required=True, example="testpw123!", help='test'),
+    "name" : fields.String(description="유저의 이름", required=True, example="testname", help='test')
     })
-FailedModel = Register.model('1-2 Register Failed json model', {
-    "status" : fields.String(description="Success or Failed", example="Failed"),
-    "message" : fields.String(description="message", example="Email Duplicated")
+RegisterPostFailedResponse = Register.inherit('1-2 Register Failed Response model', swaggerModel.BaseFailedModel, {
+    "message" : fields.String(description="오류 메시지", example="Email Duplicated")
     })
-SuccessModel = Register.model('1-3 Register/Delete Success json model', {
-    "status" : fields.String(description="Success or Failed", example="Success")
+RegisterDeleteFailedResponse = Register.inherit('1-3 Delete Failed Response model', swaggerModel.BaseFailedModel,{
+    "message" : fields.String(description="오류 메시지", example="The email could not be found. It doesn't seem to be registered.")
     })
-DeleteFailedModel = Register.model('1-4 Delete Failed json model', {
-    "status" : fields.String(description="Success or Failed", example="Failed"),
-    "message" : fields.String(description="message", example="The email could not be found. It doesn't seem to be registered.")
+RegisterPutRequest = Register.model('1-4 ChangePW Request model', {
+    "email" : fields.String(description="유저의 이메일", required=True, example="testemail@testdomain.com"),
+    "new_password" : fields.String(description="유저의 새로운 비밀번호", required=True, example="testpw2!"),
+    "new_password_again" : fields.String(description="유저의 새로운 비밀번호", required=True, example="testpw2!")
     })
-ChangePW_Fileds = Register.model('1-2 ChangePW Request json model', {
-    "email" : fields.String(description="your email", required=True, example="testemail@testdomain.com"),
-    "new_password" : fields.String(description="your original password", required=True, example="testpw2!"),
-    "new_password_again" : fields.String(description="your new password ", required=True, example="testpw2!")
+ChangeFailedModel_1 = Register.inherit('1-5 ChangePW Failed_2 Response model', swaggerModel.BaseFailedModel,{
+    "message" : fields.String(description="오류 메시지", example="Wrong email")
     })
-ChangeSucessModel = Register.model('1-5 ChangePW Success json model', {
-    "status" : fields.String(description="Success or Failed", example="Success"),
-    "message" : fields.String(description="message", example="The password has changed.")
-    })
-ChangeFailedModel_1 = Register.model('1-7 ChangePW Failed_2 json model', {
-    "status" : fields.String(description="Success or Failed", example="Success"),
-    "message" : fields.String(description="message", example="Wrong email")
-    })
-ChangeFailedModel_2 = Register.model('1-6 ChangePW Failed_1 json model', {
-    "status" : fields.String(description="Success or Failed", example="Success"),
-    "message" : fields.String(description="message", example="The two passwords entered are different")
+ChangeFailedModel_2 = Register.inherit('1-6 ChangePW Failed_1 Response model', swaggerModel.BaseFailedModel, {
+    "message" : fields.String(description="오류 메시지", example="The two passwords entered are different")
     })
 
 # 일반 이메일 회원가입, 회원탈퇴 클래스
 @Register.route('/register')
+@Register.response(500, 'Failed(서버 관련 이슈)', swaggerModel.InternalServerErrorModel)
 class register(Resource):
-    @Register.doc(params={"email" : "your email", "password" : "your password(영어+숫자+특수문자의 8자리 이상 20자리 미만)", "name" : "your name"})
-    @Register.expect(RegisterFields)
-    @Register.response(201, 'Success', SuccessModel)
-    @Register.response(400, 'Failed', FailedModel)
+    @Register.expect(RegisterPostRequest)
+    @Register.doc(description='test')
+    @Register.response(201, 'Success', swaggerModel.BaseSuccessModel)
+    @Register.response(400, 'Failed(회원가입 실패, 이미 가입되어 있는 이메일일 경우)', RegisterPostFailedResponse)
     # request 유효성 검사
     @validate_params(
         Param('email', JSON, str, rules=[Pattern(r'^[\w+-_.]+@[\w-]+\.[a-zA-Z-.]+$')]),   # 이메일 형식 체크
@@ -65,7 +54,7 @@ class register(Resource):
     )
     # 회원 가입 API
     def post(self, *args):
-        """json객체로 보내진 email, name, password로 회원가입"""
+        """클라이언트로부터 회원 정보를 받아 회원가입을 수행하고 결과를 반환한다."""
         # json형식으로 data parsing, mysql connection을 위한 객체 생성
         data = request.json
         db = database.DBClass()
@@ -85,11 +74,15 @@ class register(Resource):
 
     # 회원 탈퇴 API
     @Register.expect(parser)
+    @Register.response(200, 'Success(회원탈퇴 성공)', swaggerModel.BaseSuccessModel)
+    @Register.response(400, 'Failed(이미 탈퇴되었거나 가입되지 않은 이메일일 경우)', RegisterDeleteFailedResponse)
+    @Register.response(401, 
+    'Failed(jwt 토큰 관련 이슈)\nmessage : Missing Authorization Header(header에 jwt토큰이 존재하지 않을 때)\nmessage : Token has been revoked(토큰이 blocklist에 존재할 때)\nmessage : Token has expired(토큰이 만료되었을 때)',
+    swaggerModel.NoAuthModel
+    )
     @jwt_required()
-    @Register.response(200, 'Success', SuccessModel)
-    @Register.response(401, 'Failed', DeleteFailedModel)
     def delete(self, *args):
-        """Authorization header에 존재하는 jwt토큰에서 email을 분리하여 회원 탈퇴"""
+        """클라이언트로부터 받은 jwt토큰에서 이메일을 분리하여 회원탈퇴를 수행하고 결과를 반환한다."""
         userEmail = get_jwt_identity()
         jti = get_jwt()['jti']
         db = database.DBClass()
@@ -107,7 +100,7 @@ class register(Resource):
         dbdata = dbdata['email']
 
         if dbdata is None:
-            return {"status":"Failed", "message": "The email could not be found. It doesn't seem to be registered."}, 401
+            return {"status":"Failed", "message": "The email could not be found. It doesn't seem to be registered."}, 400
         else:
             query = '''
                 DELETE FROM users WHERE email=(%s);
@@ -117,12 +110,12 @@ class register(Resource):
             return { "status" : "Success" }, 200
     
     # 비밀번호 변경 API
-    @Register.expect(ChangePW_Fileds)
-    @Register.response(201, 'Success', ChangeSucessModel)
-    @Register.response(400, 'Failed(입력한 비밀번호가 서로 다를때)', ChangeFailedModel_2)
-    @Register.response(400, 'Failed(입력한 email이 틀렸을 때)', ChangeFailedModel_1)
+    @Register.expect(RegisterPutRequest)
+    @Register.response(201, 'Success', swaggerModel.BaseSuccessModel)
+    @Register.response(400, 'Failed(입력한 비밀번호가 서로 다를 경우)', ChangeFailedModel_2)
+    @Register.response(400, 'Failed(입력한 email이 틀렸을 경우)', ChangeFailedModel_1)
     def put(self, *args):
-        """json객체로 보내진 email, password"""
+        """클라이언트로부터 비밀번호를 받아서 비밀번호 변경을 수행한다."""
         data = request.json
 
         db = database.DBClass()
@@ -135,6 +128,6 @@ class register(Resource):
 
         if db.executeOne(query_list[0], data):
             db.execute_and_commit(query_list[1], data)
-            return {"status":"Success", "message":"The password has changed"},200
+            return {"status":"Success"},200
         else:
             return {"status":"Failed", "message": "Wrong email"}, 400

--- a/2021_2_backEnd/backendDB_ver_10_06.sql
+++ b/2021_2_backEnd/backendDB_ver_10_06.sql
@@ -17,8 +17,8 @@ CREATE TABLE users (
   email varchar(200) DEFAULT NULL,
   password varchar(200) DEFAULT NULL,
   name varchar(200) DEFAULT NULL,
-  kakaoAccessToken varchar(200) DEFAULT NULL,
-  kakaoRefreshToken varchar(200) DEFAULT NULL,
+  fcmToken varchar(200) DEFAULT NULL,
+  profilePhoto varchar(200) DEFAULT NULL,
   PRIMARY KEY (id),
   UNIQUE KEY `uniqueEmail` (email)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
1. api문서 작성 완료
 - register, auth, profile, kakao, notification, fcmtoken의 api문서 작성 완료
2. user 테이블 column 변경
 - 사용하지 않는 kakaoAccessToken, kakaoRefreshToken을 삭제하고 fcmToken, profilePhoto column 추가
 - backendDB_ver_10_06에 반영해놓음
3. api 작성 및 수정
 - image API 작성 : 특정 이미지 파일을 반환하는 api, 프로필사진 기능에 사용됨
 - profile API 수정 : route를 /profile/{userEmail}에서 /profile로 변경
  -> jwt토큰에서 유저의 이메일을 분리할 수 있어서 path형태로 이메일을 받을 필요가 없음(get_jwt_identity() 사용)